### PR TITLE
fix: Populate npm scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,15 @@
   "description": "A web application for interactive chess puzzles, built with TypeScript and tested with Jest.",
   "main": "dist/js/main.js",
   "scripts": {
-    "comment": "Scripts for build, test, lint, and dev server will be added in subsequent steps"
+    "build": "tsc",
+    "lint": "eslint \"js/**/*.ts\" \"tests/**/*.ts\"",
+    "lint:fix": "eslint \"js/**/*.ts\" \"tests/**/*.ts\" --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage",
+    "dev:watch-ts": "nodemon",
+    "dev:live-reload": "live-server --watch=dist,index.html --open",
+    "start": "npm-run-all --parallel dev:watch-ts dev:live-reload"
   },
   "keywords": [
     "chess",
@@ -18,7 +26,16 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@types/jest": "^29.5.0",
+    "eslint": "^8.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.7.0",
+    "live-server": "^1.2.2",
+    "nodemon": "^3.0.0",
+    "npm-run-all": "^4.1.5",
+    "prettier": "^3.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
This commit updates the `package.json` file to include all the necessary npm scripts for building, linting, testing, and running the development server.

Previously, while I designed the scripts and created configurations for tools like Nodemon and ESLint, I hadn't updated the `package.json` itself with these scripts after its initial creation.

I've added/updated the following scripts in `package.json`:
- `build`: Compiles TypeScript using `tsc`.
- `lint`: Lints TypeScript files using ESLint.
- `lint:fix`: Lints and attempts to auto-fix issues.
- `test`: Runs Jest tests.
- `test:watch`: Runs Jest in watch mode.
- `test:coverage`: Runs Jest and generates a coverage report.
- `dev:watch-ts`: Runs Nodemon to watch TypeScript files and trigger recompilation.
- `dev:live-reload`: Runs `live-server` to serve the application with live reloading.
- `start`: Runs `dev:watch-ts` and `dev:live-reload` concurrently using `npm-run-all`.

I also reviewed the `devDependencies` in `package.json` to ensure `npm-run-all` is included, as it's a dependency for the `start` script.

This change ensures that you can use standard npm commands to manage the project's lifecycle.